### PR TITLE
Updated plugin to be more compatible and comfortable to use

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,5 +10,5 @@ type PackageObject = {
 
 export default function (
   packages: Package[],
-  //options?: { ... }
+  options?: { alwaysRebuild?: boolean }
 ): Plugin;

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "vite-plugin-tree-sitter",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "type": "module",
   "main": "./index.js",
   "types": "./index.d.ts",
   "keywords": ["tree-sitter", "vite-plugin"],
   "author": "milahu",
-  "license": "CC0-1.0"
+  "license": "MIT"
 }


### PR DESCRIPTION
* updated `emcc` flags based on source work (`wasm.rs`)
  * indicated revision date in code to help future maintainers
* implemented optional inclusion of 'scanner' sources
  * these will be built if and only if they exist (copied logic from `wasm.rs`)
* added plugin option to control whether to rebuild on every start
  * by default it does not