### PR TITLE
Update to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ export default defineConfig({
    logLevel: "INFO",
   }),
  ],
+ // following is required for web-tree-sitter.wasm to appear in dev-mode
+ optimizeDeps: { exclude: ["web-tree-sitter"] },
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ export default defineConfig({
   }),
  ],
  // following is required for web-tree-sitter.wasm to appear in dev-mode
+ // until https://github.com/vitejs/vite/issues/8427 is addressed
  optimizeDeps: { exclude: ["web-tree-sitter"] },
 })
 ```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ instructions for supported platforms are described there.
 
 ## Changelog
 
+- `0.3.1` 2026-01-19 : updated documentation and examples
 - `0.3.0` 2026-01-17 : upgraded dependencies
   - removed special handling for web-tree-sitter (0.26 no longer requires it)
 - `0.2.10` 2025-06-21 : added CLI mode to node implementation

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guyven/vite-plugin-tree-sitter",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"exports": "./mod.ts",
 	"license": "MIT",
 	"imports": {

--- a/mod.ts
+++ b/mod.ts
@@ -82,7 +82,7 @@ export default function (
 
 	return {
 		name: pluginName,
-		version: "0.3.0",
+		version: "0.3.1",
 		apply: ({ mode }) => {
 			runMode =
 				mode == "development" ? "DEV"

--- a/mod.ts
+++ b/mod.ts
@@ -82,7 +82,7 @@ export default function (
 
 	return {
 		name: pluginName,
-		version: "0.2.10",
+		version: "0.3.0",
 		apply: ({ mode }) => {
 			runMode =
 				mode == "development" ? "DEV"


### PR DESCRIPTION
`web-tree-sitter` after `0.26` has changed both it's helper wasm filename, and tweaked how it is notified to javascript that is more bundler-friendly than before.  As a result of this, our previous bundler-helper code that served `tree-sitter.wasm` to the bundle if it was noticed in the project (now renamed to `web-tree-sitter.wasm`) was both broken and finally unneeded.

The seemingly correct way to handle `web-tree-sitter` now is to allow it to bundle on it's own (vite build sees it and picks it up automatically), and accept that while it still doesn't serve properly in vite's dev mode, this can be overcome with a vite settings addition:

```javascript
// vite.config.ts
export default defineConfig({
	// ...
	// following is required for web-tree-sitter.wasm to appear in dev-mode
	optimizeDeps: { exclude: ["web-tree-sitter"] },
})
```

This tells vite to disable it's internal caching of that particular package, which enables the `.wasm` to be found by code running in dev-mode.  I don't believe this impacts production builds at all.

This PR does not include any code changes (other than version bumps), this merely adds this setting to the example documentation in the README.